### PR TITLE
add winter 2021 dates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -44,6 +44,10 @@ const QUARTER_DATES = {
     instructionBegins: { year: 2020, month: 8, day: 30, hour: 8, minute: 0 },
     instructionEnds: { year: 2020, month: 11, day: 11, hour: 23, minute: 59 }
   },
+  'Winter 2021': {
+    instructionBegins: { year: 2020, month: 0, day: 4, hour: 8, minute: 0 },
+    instructionEnds: { year: 2020, month: 2, day: 12, hour: 23, minute: 59 }
+  },
 };
 
 /**

--- a/src/App.js
+++ b/src/App.js
@@ -45,8 +45,12 @@ const QUARTER_DATES = {
     instructionEnds: { year: 2020, month: 11, day: 11, hour: 23, minute: 59 }
   },
   'Winter 2021': {
-    instructionBegins: { year: 2020, month: 0, day: 4, hour: 8, minute: 0 },
-    instructionEnds: { year: 2020, month: 2, day: 12, hour: 23, minute: 59 }
+    instructionBegins: { year: 2021, month: 0, day: 4, hour: 8, minute: 0 },
+    instructionEnds: { year: 2021, month: 2, day: 12, hour: 23, minute: 59 }
+  },
+  'Spring 2021': {
+    instructionBegins: { year: 2021, month: 2, day: 29, hour: 8, minute: 0 },
+    instructionEnds: { year: 2021, month: 5, day: 4, hour: 23, minute: 59 }
   },
 };
 


### PR DESCRIPTION
updating the schedule exporter and making a pull request still beats typing them in manually.
please pull this and update the chrome store release.